### PR TITLE
Auto Scaling groups created

### DIFF
--- a/asg-policies.tf
+++ b/asg-policies.tf
@@ -1,0 +1,99 @@
+resource "aws_autoscaling_policy" "asg1-cpu-scale-up-policy" {
+  name                   = "asg1-cpu-scale-up-policy"
+  autoscaling_group_name = module.asg1.this_autoscaling_group_name
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  scaling_adjustment     = 1
+}
+
+resource "aws_cloudwatch_metric_alarm" "asg1-cpu-scale-up-alarm" {
+  alarm_name          = "asg1-cpu-alarm-scale-up"
+  alarm_description   = "asg1-cpu-alarm-scale-up"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "70"
+  dimensions = {
+    "AutoScalingGroupName" = module.asg1.this_autoscaling_group_name
+  }
+  actions_enabled = true
+  alarm_actions   = [aws_autoscaling_policy.asg1-cpu-scale-up-policy.arn]
+}
+
+resource "aws_autoscaling_policy" "asg1-cpu-scale-down-policy" {
+  name                   = "asg1-cpu-scale-down-policy"
+  autoscaling_group_name = module.asg1.this_autoscaling_group_name
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  scaling_adjustment     = -1
+}
+
+resource "aws_cloudwatch_metric_alarm" "asg1-cpu-scale-down-alarm" {
+  alarm_name          = "asg1-cpu-alarm-scale-down"
+  alarm_description   = "asg1-cpu-alarm-scale-down"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "20"
+  dimensions = {
+    "AutoScalingGroupName" = module.asg1.this_autoscaling_group_name
+  }
+  actions_enabled = true
+  alarm_actions   = [aws_autoscaling_policy.asg1-cpu-scale-down-policy.arn]
+}
+
+resource "aws_autoscaling_policy" "asg2-cpu-scale-up-policy" {
+  name                   = "asg2-cpu-scale-up-policy"
+  autoscaling_group_name = module.asg2.this_autoscaling_group_name
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  scaling_adjustment     = 1
+}
+
+resource "aws_cloudwatch_metric_alarm" "asg2-cpu-scale-up-alarm" {
+  alarm_name          = "asg2-cpu-alarm-scale-up"
+  alarm_description   = "asg2-cpu-alarm-scale-up"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "70"
+  dimensions = {
+    "AutoScalingGroupName" = module.asg2.this_autoscaling_group_name
+  }
+  actions_enabled = true
+  alarm_actions   = [aws_autoscaling_policy.asg2-cpu-scale-up-policy.arn]
+}
+
+resource "aws_autoscaling_policy" "asg2-cpu-scale-down-policy" {
+  name                   = "asg2-cpu-scale-down-policy"
+  autoscaling_group_name = module.asg2.this_autoscaling_group_name
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  scaling_adjustment     = -1
+}
+
+resource "aws_cloudwatch_metric_alarm" "asg2-cpu-scale-down-alarm" {
+  alarm_name          = "asg2-cpu-alarm-scale-down"
+  alarm_description   = "asg2-cpu-alarm-scale-down"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "20"
+  dimensions = {
+    "AutoScalingGroupName" = module.asg2.this_autoscaling_group_name
+  }
+  actions_enabled = true
+  alarm_actions   = [aws_autoscaling_policy.asg2-cpu-scale-down-policy.arn]
+}

--- a/asg.tf
+++ b/asg.tf
@@ -1,0 +1,87 @@
+# https://registry.terraform.io/modules/terraform-aws-modules/autoscaling
+
+module "asg1" {
+  source = "terraform-aws-modules/autoscaling/aws"
+  name   = "asg1"
+
+  # Launch configuration
+  lc_name                      = "asg1-lc"
+  image_id                     = data.aws_ami.latest_amzn_ami.id
+  instance_type                = var.instance_type
+  security_groups              = [module.web_server_sg.this_security_group_id]
+  recreate_asg_when_lc_changes = true
+  user_data                    = data.template_cloudinit_config.asg1.rendered
+
+  # Auto scaling group
+  asg_name                  = "asg1"
+  vpc_zone_identifier       = [module.vpc.private_subnets[0]]
+  health_check_type         = "EC2"
+  min_size                  = 1
+  max_size                  = 5
+  desired_capacity          = 1
+  wait_for_capacity_timeout = 0
+
+  tags = [
+    {
+      key                 = "Terraform"
+      value               = "true"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Environment"
+      value               = "dev"
+      propagate_at_launch = true
+    },
+  ]
+}
+
+module "asg2" {
+  source = "terraform-aws-modules/autoscaling/aws"
+  name   = "asg2"
+
+  # Launch configuration
+  lc_name                      = "asg2-lc"
+  image_id                     = data.aws_ami.latest_amzn_ami.id
+  instance_type                = var.instance_type
+  security_groups              = [module.web_server_sg.this_security_group_id]
+  recreate_asg_when_lc_changes = true
+  user_data                    = data.template_cloudinit_config.asg2.rendered
+
+  # Auto scaling group
+  asg_name                  = "asg2"
+  vpc_zone_identifier       = [module.vpc.private_subnets[1]]
+  health_check_type         = "EC2"
+  min_size                  = 1
+  max_size                  = 5
+  desired_capacity          = 1
+  wait_for_capacity_timeout = 0
+
+  tags = [
+    {
+      key                 = "Terraform"
+      value               = "true"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Environment"
+      value               = "dev"
+      propagate_at_launch = true
+    },
+  ]
+}
+
+# resource "aws_autoscaling_policy" "asg2" {
+#   name                   = "asg2-policy"
+#   autoscaling_group_name = module.asg2.this_autoscaling_group_name
+#   adjustment_type        = "ChangeInCapacity"
+#   policy_type            = "TargetTrackingScaling"
+#   target_tracking_configuration {
+#     predefined_metric_specification {
+#       predefined_metric_type = "ASGAverageCPUUtilization"
+#     }
+
+#     target_value = 70.0
+#   }
+#   #   cooldown               = 300
+#   #   scaling_adjustment     = 1
+# }

--- a/data.tf
+++ b/data.tf
@@ -25,3 +25,45 @@ data "aws_ami" "latest_amzn_ami" {
 
   owners = ["amazon"]
 }
+
+# Render a part using a `template_file: 
+# https://www.terraform.io/docs/providers/template/d/cloudinit_config.html
+data "template_file" "cloud-config-packages" {
+  template = "${file("${path.module}/templates/cloud-config-packages.tpl")}"
+}
+
+# Render a part using a `template_file: 
+data "template_file" "cloud-config-runcmd1" {
+  template = "${file("${path.module}/templates/cloud-config-runcmd.tpl")}"
+    vars = {
+    asg     = "asg1"
+  }
+}
+
+# Render a multi-part cloud-init config making use of the part above, and other source files
+data "template_cloudinit_config" "asg1" {
+  part {
+    content = "${data.template_file.cloud-config-packages.rendered}"
+  }
+  part {
+    content = "${data.template_file.cloud-config-runcmd1.rendered}"
+  }
+}
+
+# Render a part using a `template_file: 
+data "template_file" "cloud-config-runcmd2" {
+  template = "${file("${path.module}/templates/cloud-config-runcmd.tpl")}"
+    vars = {
+    asg     = "asg2"
+  }
+}
+
+# Render a multi-part cloud-init config making use of the part above, and other source files
+data "template_cloudinit_config" "asg2" {
+  part {
+    content = "${data.template_file.cloud-config-packages.rendered}"
+  }
+  part {
+    content = "${data.template_file.cloud-config-runcmd2.rendered}"
+  }
+}

--- a/security.tf
+++ b/security.tf
@@ -9,7 +9,7 @@ module "alb_sg" {
 
   ingress_cidr_blocks = ["0.0.0.0/0"]
   ingress_rules       = ["http-80-tcp"]
-  # there is two private subnet where ASG will be deployed to
+  # there are two private subnets where ASGs will be deployed to
   egress_cidr_blocks  = tolist(module.vpc.private_subnets_cidr_blocks) 
 }
 

--- a/templates/cloud-config-packages.tpl
+++ b/templates/cloud-config-packages.tpl
@@ -1,0 +1,6 @@
+#cloud-config
+repo_update: true
+repo_upgrade: all
+packages:
+  - tree
+  - httpd

--- a/templates/cloud-config-runcmd.tpl
+++ b/templates/cloud-config-runcmd.tpl
@@ -1,0 +1,5 @@
+#cloud-config
+runcmd:
+  - echo '<h1>Welcome to ${asg}</h1>' | tree -a /var/www/html/index.html
+  - chkconfig httpd on
+  - service httpd start


### PR DESCRIPTION

- Two auto scaling groups are created; one each in private zones
- Auto scaling policies are also created to scale up / down EC2 instances depending on CPU utilization

Fixes #2